### PR TITLE
grab api key from APPSEMBLER_FEATURES in server-vars.yml

### DIFF
--- a/views.py
+++ b/views.py
@@ -6,6 +6,7 @@ import logging
 from django.contrib.auth.models import User
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
+from django.conf import settings
 
 from capa.xqueue_interface import XQUEUE_METRIC_NAME
 from certificates.models import certificate_status_for_student, CertificateStatuses, GeneratedCertificate
@@ -28,7 +29,7 @@ def request_certificate(request):
     if request.method == "POST":
         if request.user.is_authenticated():
             # Enter your api key here
-            xqci = CertificateGeneration(api_key="Your_API_KEY")
+            xqci = CertificateGeneration(api_key=settings.APPSEMBLER_FEATURES['ACCREDIBLE_API_KEY')
             username = request.user.username
             student = User.objects.get(username=username)
             course_key = SlashSeparatedCourseKey.from_deprecated_string(request.POST.get('course_id'))


### PR DESCRIPTION
Pretty self-explanatory. Grabbing api key from APPSEMBLER_FEATURES, which is loaded into django.conf.settings via server-vars.yml.

@mbifulco let me know if you have any questions.
